### PR TITLE
Do not reinstanciate less parser to keep includedir param

### DIFF
--- a/autoloads/ezless.php
+++ b/autoloads/ezless.php
@@ -248,7 +248,6 @@ class ezLessOperator{
 
             if( $useOneFile == "true" ){
                 $file = md5(uniqid(mt_rand(), true)) . ".css";
-                $less = new lessc();
                 try
                 {
                     $parsedContent = $less->parse( $cssContent );


### PR DESCRIPTION
When generating only one file, less parser was reinstanciated and the previously set includeDir property was lost. 
